### PR TITLE
fix for bbox center_y calc

### DIFF
--- a/apps/tao_others/deepstream-faciallandmark-app/ds_facialmark_meta.h
+++ b/apps/tao_others/deepstream-faciallandmark-app/ds_facialmark_meta.h
@@ -50,7 +50,7 @@ typedef struct {
     float width() { return right - left; }
     float height() { return bottom - top; }
     float center_x() { return left + width() / 2; }
-    float center_y() { return right + height() / 2; }
+    float center_y() { return top + height() / 2; }
 }BBox;
 
 typedef struct


### PR DESCRIPTION
    float center_y() { return right + height() / 2; }
just looks wrong